### PR TITLE
Update internal separator in the macro \lstKV@SwitchCases

### DIFF
--- a/lstlinebgrd.sty
+++ b/lstlinebgrd.sty
@@ -17,10 +17,10 @@
 \lst@Key{numbers}{none}{%
     \def\lst@PlaceNumber{\lst@linebgrd}%
     \lstKV@SwitchCases{#1}%
-    {none&\\%
-     left&\def\lst@PlaceNumber{\llap{\normalfont
+    {none:\\%
+     left:\def\lst@PlaceNumber{\llap{\normalfont
                 \lst@numberstyle{\thelstnumber}\kern\lst@numbersep}\lst@linebgrd}\\%
-     right&\def\lst@PlaceNumber{\rlap{\normalfont
+     right:\def\lst@PlaceNumber{\rlap{\normalfont
                 \kern\linewidth \kern\lst@numbersep
                 \lst@numberstyle{\thelstnumber}}\lst@linebgrd}%
     }{\PackageError{Listings}{Numbers #1 unknown}\@ehc}}


### PR DESCRIPTION
## Problem

lstlistings changed these separators from `&` to `:` in 2018 which broke this code.

## Solution

As suggested [here](https://tex.stackexchange.com/a/451538/262978) the separators are updated.

## Linked Issues

- [x] closes #1 

## Minimal example:
One line of "code" with red background (content of the document is not actually needed to trigger the error).
`main.tex`:
```latex
\documentclass{minimal}
\usepackage{lstlinebgrd}
\begin{document}
  \begin{lstlisting}[
    linebackgroundcolor=\color{red},
  ]
    HelloWorld!
  \end{lstlisting}
\end{document}
```
Compile with:
```bash
pdflatex main.tex
```
<details>
<summary>
Yields this error
</summary>

```
$ pdflatex main.tex
This is pdfTeX, Version 3.141592653-2.6-1.40.22 (TeX Live 2022/dev/Debian) (preloaded format=pdflatex)
 restricted \write18 enabled.
entering extended mode
(./main.tex
LaTeX2e <2021-11-15> patch level 1
L3 programming layer <2022-01-21>
(/usr/share/texlive/texmf-dist/tex/latex/base/minimal.cls
Document Class: minimal 2001/05/25 Standard LaTeX minimal class
) (/usr/share/texlive/texmf-dist/tex/latex/lstaddons/lstlinebgrd.sty
(/usr/share/texlive/texmf-dist/tex/latex/listings/listings.sty
(/usr/share/texlive/texmf-dist/tex/latex/graphics/keyval.sty)
(/usr/share/texlive/texmf-dist/tex/latex/listings/lstmisc.sty)
(/usr/share/texlive/texmf-dist/tex/latex/listings/listings.cfg))
(/usr/share/texlive/texmf-dist/tex/latex/xcolor/xcolor.sty
(/usr/share/texlive/texmf-dist/tex/latex/graphics-cfg/color.cfg)
(/usr/share/texlive/texmf-dist/tex/latex/graphics-def/pdftex.def))

! Package Listings Error: Numbers none unknown.

See the Listings package documentation for explanation.
Type  H <return>  for immediate help.
 ...

l.37 ...Error{Listings}{Numbers #1 unknown}\@ehc}}

?
! Emergency stop.
 ...

l.37 ...Error{Listings}{Numbers #1 unknown}\@ehc}}

!  ==> Fatal error occurred, no output PDF file produced!
Transcript written on main.log.

```
</details>

With the suggested changes the example compiles as expected.
