### PR TITLE
Update lstlinebgrd.dtx (fix year date)

### DIFF
--- a/lstlinebgrd.dtx
+++ b/lstlinebgrd.dtx
@@ -24,7 +24,7 @@
 %<*driver>
 \ProvidesFile{lstlinebgrd.dtx}[%
 %<=*DATE>
-    2014/08/18
+    2024/08/18
 %<=/DATE>
 %<=*VERSION>
     v0.2


### PR DESCRIPTION
Replacing of 2014 by 2024 for the year or the version 0.2 (as stated at https://www.ctan.org/pkg/lstaddons: Version	0.2 2024-08-18)